### PR TITLE
Allow lambda to accept events from both s3 and sns

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -271,7 +271,7 @@ def get_s3_event(event):
     if "s3" in record:
         return record["s3"]
 
-    if "sns" in record:
+    if "Sns" in record:
         sns_message = record["Sns"]["message"]
         s3_event = json.loads(sns_message)
         return s3_event["Records"][0]["s3"]


### PR DESCRIPTION
We would like to use SNS to read s3 object created events. However, the existing lambda didn't quite allow that. This PR fixes that.